### PR TITLE
Fix reversed ST and GT when the note is written in digit.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-08-01  Koichi INOUE  <inoue@windy.local>
+
+	* ST and GT was reversed when the note was written in digit.
+
 2015-07-31  Koichi INOUE  <inoue@windy.local>
 
 	* Exchange 2nd and 3rd colum in text notation. The order is now step time and gate time, which is generally accepted.

--- a/lib/text_sequencer/parser.rb
+++ b/lib/text_sequencer/parser.rb
@@ -61,7 +61,7 @@ module TextSequencer
     def note_digit(record)
       (1..3).each { |i| record[i] = int_value(record[i]) }
       note = record.first.to_i
-      gt, st = calc_note_timing(record)
+      st, gt = calc_note_timing(record)
       velocity = record[3] || @velocity
       @sequence.push([:note, note, gt, st, velocity])
     end
@@ -132,7 +132,7 @@ module TextSequencer
       if st && gt
         return st.quo(@base), gt.quo(@base)
       elsif st
-        return st.quo(@base), (st == 0 ? 1 : st.quo(@base))
+        return st.quo(@base), 1.0
       else
         return 1.0, 1.0
       end


### PR DESCRIPTION
In previous exchange of ST and GT field, it was mistakenly reversed in note_digit().
This branch should fix it.
