### PR TITLE
Add step and gate command

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2015-08-01  Koichi INOUE  <inoue@windy.local>
 
+	* Add `step` and `gate` command to set default ST and GT respectively.
+
 	* Raise error on unclosed parentheses at the end of input.
 
 	* ST and GT was reversed when the note was written in digit.

--- a/examples/example.txt
+++ b/examples/example.txt
@@ -1,4 +1,6 @@
 base 48
+step 48
+gate 40
 vel 120
 
 chord1(

--- a/lib/text_sequencer/parser.rb
+++ b/lib/text_sequencer/parser.rb
@@ -11,6 +11,8 @@ module TextSequencer
       @stack.push(sequencer.sequence)
       @sequence = @stack.last
       @base = DEFAULT_BASE
+      @step = DEFAULT_BASE
+      @gate = DEFAULT_BASE
       @row = DEFAULT_ROW
       @velocity = DEFAULT_VELOCITY
       @line_num = 0
@@ -90,12 +92,9 @@ module TextSequencer
 
     def command(record)
       case record[0]
-      when 'base'
+      when 'base', 'step', 'gate', 'row'
         fail ParseError.new(@line_num, record.join(' ')) if record.length != 2
-        @base = record[1].to_i
-      when 'row'
-        fail ParseError.new(@line_num, record.join(' ')) if record.length != 2
-        @row = record[1].to_i
+        instance_variable_set("@#{record[0]}".to_sym, record[1].to_i)
       when 'vel', 'velocity'
         fail ParseError.new(@line_num, record.join(' ')) if record.length != 2
         @velocity = record[1].to_i
@@ -137,9 +136,9 @@ module TextSequencer
       if st && gt
         return st.quo(@base), gt.quo(@base)
       elsif st
-        return st.quo(@base), 1.0
+        return st.quo(@base), @gate.quo(@base)
       else
-        return 1.0, 1.0
+        return @step.quo(@base), @gate.quo(@base)
       end
     end
 


### PR DESCRIPTION
Add `step` and `gate` command to set default step time and gate time respectively.
Now `base` `step` and `gate` controls how these values are set if it is ommited.
